### PR TITLE
Don't flatten Images

### DIFF
--- a/src/akro/image.py
+++ b/src/akro/image.py
@@ -32,3 +32,31 @@ class Image(Box):
         """
         assert isinstance(other, Image)
         return super().concat(other)
+
+    def flatten(self, x):
+        """Return a flattened observation x.
+
+        Note: Image observations should never be flattened, so a call to
+            flatten returns the observation
+
+        Returns:
+            np.ndarray: An array of x collapsed into one dimension.
+
+        """
+        return x
+
+    def flatten_n(self, obs):
+        """Return flattened observations obs.
+
+        Note: Image observations should never be flattened, so a call to
+            flatten returns the observation
+
+        Args:
+            obs (:obj:`Iterable`): The object to reshape and flatten
+
+        Returns:
+            np.ndarray: An array of obs in a shape inferred by the size of
+                its first element.
+
+        """
+        return x

--- a/tests/akro/test_image.py
+++ b/tests/akro/test_image.py
@@ -32,3 +32,11 @@ class TestImage(unittest.TestCase):
         concat_image = img1.concat(img2)
 
         assert concat_image.flat_dim == img1.flat_dim + img2.flat_dim
+
+    def test_does_not_flatten(self):
+        """Images should never be flattenable."""
+        obj = Image((3, 3, 3))
+        x = obj.sample()
+        assert np.all(np.array_equal(x, obj.flatten(x)))
+        l = np.array([x, x, x])
+        assert np.all(np.array_equal(l, obj.flatten(l)))


### PR DESCRIPTION
Flattening images causes information about their
structure to be lost. This commit changes the flattening
properties of Images to be identity functions.