### PR TITLE
Fix tf imports in some test files

### DIFF
--- a/tests/akro/test_discrete.py
+++ b/tests/akro/test_discrete.py
@@ -3,9 +3,9 @@ import unittest
 
 import numpy as np
 import pytest
-import tensorflow as tf
 
 from akro import Discrete
+from akro import tf
 from akro import theano
 from akro.requires import requires_tf, requires_theano
 

--- a/tests/akro/test_tuple.py
+++ b/tests/akro/test_tuple.py
@@ -2,10 +2,10 @@ import pickle
 import unittest
 
 import numpy as np
-import tensorflow as tf
 
 from akro import Box
 from akro import Discrete
+from akro import tf
 from akro import theano
 from akro import Tuple
 from akro.requires import requires_tf, requires_theano


### PR DESCRIPTION
Changed `import tensorflow as tf` to `from akro import tf`
so that tests will still run if tensorflow is not installed.

This makes tf imports in these files consistent with the other test
files.