### PR TITLE
Fix hash unit tests

### DIFF
--- a/tests/akro/test_box.py
+++ b/tests/akro/test_box.py
@@ -118,8 +118,9 @@ class TestBox(unittest.TestCase):
                             np.full(box2.flat_dim, 2)]))
 
     def test_hash(self):
-        box = Box(0.0, 1.0, (3, 4))
-        assert box.__hash__() == 1213972508617964782
+        box1 = Box(0.0, 1.0, (3, 4))
+        box2 = Box(0.0, 1.0, (3, 4))
+        assert box1.__hash__() == box2.__hash__()
 
     @requires_tf
     def test_convert_tf(self):

--- a/tests/akro/test_discrete.py
+++ b/tests/akro/test_discrete.py
@@ -68,8 +68,9 @@ class TestDiscrete(unittest.TestCase):
             disc1.concat(disc2)
 
     def test_hash(self):
-        disc = Discrete(10)
-        assert disc.__hash__() == 10
+        disc1 = Discrete(10)
+        disc2 = Discrete(10)
+        assert disc1.__hash__() == disc2.__hash__()
 
     @requires_tf
     def test_convert_tf(self):

--- a/tests/akro/test_tuple.py
+++ b/tests/akro/test_tuple.py
@@ -59,8 +59,9 @@ class TestTuple(unittest.TestCase):
         assert concat_tup.flat_dim == 30
 
     def test_hash(self):
-        tup = Tuple((Discrete(3), Discrete(2)))
-        assert tup.__hash__() == 3713083796995235906
+        tup1 = Tuple((Discrete(3), Discrete(2)))
+        tup2 = Tuple((Discrete(3), Discrete(2)))
+        assert tup1.__hash__() == tup2.__hash__()
 
     @requires_tf
     def test_convert_tf(self):


### PR DESCRIPTION
Python hash() values are not guaranteed to be reproducible so tests should not check hash values directly.
See [here](https://docs.python.org/3/reference/datamodel.html#object.__hash__) for details.

The only guaranteed property is that objects that compare equal have the same hash value so the new tests check that instead.